### PR TITLE
Fix cm nav

### DIFF
--- a/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
+++ b/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
@@ -187,11 +187,10 @@ export class CreateCredentialWizard extends React.Component<
     );
   }
 
-  createCredential = async () => {
+  createCredential = () => {
     const { http } = this.context.services;
-    try {
       // TODO: Refactor it by registering client wrapper factory
-      await http
+    Promise.resolve(http
         .post('/api/credential_management/create', {
           body: JSON.stringify({
             credential_name: this.state.credentialName,
@@ -201,15 +200,13 @@ export class CreateCredentialWizard extends React.Component<
               password: this.state.password,
             },
           }),
-        })
+        }))
         .then((res) => {
           // TODO: Fix routing
-          this.props.history.push('');
+          this.props.history.goBack();
           console.log(res);
         });
-    } catch (e) {
-      console.log(e);
-    }
+
   };
 }
 

--- a/src/plugins/credential_management/public/components/credential_table/credentials_table.tsx
+++ b/src/plugins/credential_management/public/components/credential_table/credentials_table.tsx
@@ -146,8 +146,8 @@ export const CredentialsTable = ({ canSave, history }: Props) => {
 
   const onClickDelete = () => {
     Promise.resolve(deleteCredentials(savedObjects.client, selectedCredentials)).then(function () {
-      setSelectedCredentials([]);
       // TODO: Fix routing
+      setSelectedCredentials([]);
       history.push('');
     });
   };

--- a/src/plugins/credential_management/public/components/types.ts
+++ b/src/plugins/credential_management/public/components/types.ts
@@ -11,6 +11,6 @@
 
 export interface CredentialsTableItem {
   id: string;
-  credentialName: string;
+  title: string;
   sort: string;
 }


### PR DESCRIPTION
### Issues

1. After credential created, would like to return back to the credential listing page
2. After delete button clicked, would like to refresh the credential table

### Attempts
1. Replace async call to Promise.resolve() on button.onClick (X)
2. Use props.history.push('') to refresh (x)
3. Use props.history.push('/') to return back (x)
4. Add onChange function to refresh the EuiInMemoryTable component (X)
5. Remove the credential items and set state (X) - the state will not changed unless page refresh
6. hapy redirected() method (x) 
 
### Comments
1. Attempt 1,2,3 were used in current index pattern management and saved object management.
2. From debugging, the page refreshed after credential created

