### PR TITLE
Modify to use loader to get index pattern & Add dataSourceRef

### DIFF
--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -43,7 +43,13 @@ import { IndexPatternField, IIndexPatternFieldList, fieldList } from '../fields'
 import { formatHitProvider } from './format_hit';
 import { flattenHitWrapper } from './flatten_hit';
 import { FieldFormatsStartCommon, FieldFormat } from '../../field_formats';
-import { IndexPatternSpec, TypeMeta, SourceFilter, IndexPatternFieldMap } from '../types';
+import {
+  IndexPatternSpec,
+  TypeMeta,
+  SourceFilter,
+  IndexPatternFieldMap,
+  DataSourceRef,
+} from '../types';
 import { SerializedFieldFormat } from '../../../../expressions/common';
 
 interface IndexPatternDeps {
@@ -86,7 +92,8 @@ export class IndexPattern implements IIndexPattern {
   // savedObject version
   public version: string | undefined;
   public sourceFilters?: SourceFilter[];
-  public dataSourcesJSON: string | undefined;
+  public dataSourcesJSON?: string; // todo: cleanup, only keep one
+  public dataSourceRef?: DataSourceRef;
 
   private originalSavedObjectBody: SavedObjectBody = {};
   private shortDotsEnable: boolean = false;
@@ -132,7 +139,17 @@ export class IndexPattern implements IIndexPattern {
     });
 
     this.dataSourcesJSON = spec.dataSourcesJSON;
+    this.dataSourceRef = this.getDataSourceRef(spec.dataSourcesJSON);
   }
+
+  getDataSourceRef = (dataSourcesJSON?: string) => {
+    if (dataSourcesJSON) {
+      const refs = JSON.parse(dataSourcesJSON);
+      if (!_.isEmpty(refs)) {
+        return refs[0]; // only support 1-1 mapping now
+      }
+    }
+  };
 
   /**
    * Get last saved saved object fields

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -49,6 +49,7 @@ export interface IIndexPattern {
   getFormatterForField?: (
     field: IndexPatternField | IndexPatternField['spec'] | IFieldType
   ) => FieldFormat;
+  dataSourceRef?: DataSourceRef;
 }
 
 export interface IndexPatternAttributes {
@@ -194,9 +195,14 @@ export interface IndexPatternSpec {
   fields?: IndexPatternFieldMap;
   typeMeta?: TypeMeta;
   type?: string;
-  dataSourcesJSON?: string;
+  dataSourcesJSON?: string; // todo: refactor to dataSourceRefs : DataSourceRef[]
 }
 
 export interface SourceFilter {
   value: string;
+}
+
+export interface DataSourceRef {
+  id: string;
+  type: string;
 }

--- a/src/plugins/data/public/index_patterns/saved_index_patterns/_saved_index_pattern.ts
+++ b/src/plugins/data/public/index_patterns/saved_index_patterns/_saved_index_pattern.ts
@@ -23,7 +23,7 @@ export function createSavedIndexPatternClass(services: SavedObjectOpenSearchDash
       sourceFilters: 'text',
       fields: 'text',
       fieldFormatMap: 'text',
-      type: 'text',
+      type: 'keyword',
       typeMeta: 'text',
       dataSourcesJSON: 'text',
       // todo

--- a/src/plugins/data/public/index_patterns/types.ts
+++ b/src/plugins/data/public/index_patterns/types.ts
@@ -12,9 +12,9 @@ export interface IndexPatternObject {
   title: string;
   intervalName?: string;
   timeFieldName?: string;
-  sourceFilters?: SourceFilter[];
-  fields?: IndexPatternFieldMap;
-  typeMeta?: TypeMeta;
+  sourceFilters?: string;
+  fields?: string;
+  typeMeta?: string;
   type?: string;
   fieldFormatMap?: string;
   dataSourcesJSON?: string;


### PR DESCRIPTION
### Description
- Modify to use loader to get index pattern, so UI has the hydrated dataSourceJSON to use.
- populate dataSourceRef in IndexPattern data model

### Test
Tested to fetch a index pattern in data source inside visualization:

```
dataSourceRef: {
id: "1d7fff10-0181-11ed-bf9e-8b2e48184190"
type: "data-source" }
```
 
### Issues Resolved
TBA
 